### PR TITLE
Fix tests

### DIFF
--- a/ftw/recipe/checkversions/testing.py
+++ b/ftw/recipe/checkversions/testing.py
@@ -40,7 +40,7 @@ class RecipeLayer(Layer):
 
     def testTearDown(self):
         zc.buildout.testing.buildoutTearDown(self)
-        pypi_url = 'http://pypi.python.org/simple'
+        pypi_url = 'https://pypi.python.org/simple'
         zc.buildout.easy_install.default_index_url = pypi_url
         os.environ['buildout-testing-index-url'] = pypi_url
         zc.buildout.easy_install._indexes = {}


### PR DESCRIPTION
Change default_index_url to HTTPS for pypi. Pypi is https only, and redirects http requests to https.
Not sure why using http in the tests does not work anymore, but it doesn't.

fixes #7 